### PR TITLE
Allow default transformers overwrite

### DIFF
--- a/lib/transform/transform-space.js
+++ b/lib/transform/transform-space.js
@@ -1,12 +1,13 @@
 import Promise from 'bluebird'
-import { omit } from 'lodash/object'
-import * as transformers from './transformers'
+import { omit, defaults } from 'lodash/object'
+import * as defaultTransformers from './transformers'
 
 /**
  * Run transformer methods on each item for each kind of entity, in case there
  * is a need to transform data when copying it to the destination space
  */
-export default function (space, destinationSpace) {
+export default function (space, destinationSpace, customTransformers) {
+  const transformers = defaults(customTransformers, defaultTransformers)
   // TODO maybe we don't need promises here at all
   const newSpace = omit(space, 'contentTypes', 'entries', 'assets', 'locales', 'webhooks')
   return Promise.reduce(['contentTypes', 'entries', 'assets', 'locales', 'webhooks'], (newSpace, type) => {

--- a/lib/transform/transform-space.js
+++ b/lib/transform/transform-space.js
@@ -15,7 +15,7 @@ export default function (
 ) {
   const transformers = defaults(customTransformers, defaultTransformers)
   // TODO maybe we don't need promises here at all
-  const newSpace = omit(space, ...entities);
+  const newSpace = omit(space, ...entities)
   return Promise.reduce(entities, (newSpace, type) => {
     return Promise.map(
       space[type],

--- a/lib/transform/transform-space.js
+++ b/lib/transform/transform-space.js
@@ -2,15 +2,21 @@ import Promise from 'bluebird'
 import { omit, defaults } from 'lodash/object'
 import * as defaultTransformers from './transformers'
 
+export const spaceEntities = [
+  'contentTypes', 'entries', 'assets', 'locales', 'webhooks'
+];
+
 /**
  * Run transformer methods on each item for each kind of entity, in case there
  * is a need to transform data when copying it to the destination space
  */
-export default function (space, destinationSpace, customTransformers) {
+export default function (
+  space, destinationSpace, customTransformers, entities = spaceEntities
+) {
   const transformers = defaults(customTransformers, defaultTransformers)
   // TODO maybe we don't need promises here at all
-  const newSpace = omit(space, 'contentTypes', 'entries', 'assets', 'locales', 'webhooks')
-  return Promise.reduce(['contentTypes', 'entries', 'assets', 'locales', 'webhooks'], (newSpace, type) => {
+  const newSpace = omit(space, ...entities);
+  return Promise.reduce(entities, (newSpace, type) => {
     return Promise.map(
       space[type],
       (entity) => Promise.resolve({

--- a/lib/transform/transform-space.js
+++ b/lib/transform/transform-space.js
@@ -2,9 +2,9 @@ import Promise from 'bluebird'
 import { omit, defaults } from 'lodash/object'
 import * as defaultTransformers from './transformers'
 
-export const spaceEntities = [
+const spaceEntities = [
   'contentTypes', 'entries', 'assets', 'locales', 'webhooks'
-];
+]
 
 /**
  * Run transformer methods on each item for each kind of entity, in case there


### PR DESCRIPTION
I'm trying to migrate one space to another. This migration will require quite a lot of transformations. Since I plan to use this project as a submodule without modifying any of the existing code, I wanted a way to pass in the transformers for my content as a parameter.

What do you think?