### PR TITLE
Obtain errors safely in handleEntryCreationErrors

### DIFF
--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -99,7 +99,8 @@ to this space.
  */
 function handleEntryCreationErrors (entry, space, skipContentModel, destinationEntries, err) {
   if (skipContentModel && err.name === 'UnknownField') {
-    entry.transformed.fields = cleanupUnknownFields(entry.transformed.fields, err.error.details.errors)
+    const errors = get(err, 'error.details.errors')
+    entry.transformed.fields = cleanupUnknownFields(entry.transformed.fields, errors)
     return createEntry(entry, space, skipContentModel, destinationEntries)
   }
   err.originalEntry = entry.original


### PR DESCRIPTION
I ran into some problems when `details` was not present on `error`. In other places details are obtained using lodash's `get`, to circumvent this problem. Adopted the same behavior here.