### PR TITLE
fix(transforms): remove extra uploadFrom

### DIFF
--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -27,6 +27,9 @@ export function assets (asset) {
     asset.fields.file,
      (newFile, file, locale) => {
        newFile[locale] = omit(file, 'url', 'details')
+       if (newFile[locale].uploadFrom) {
+         delete newFile[locale].uploadFrom
+       }
        newFile[locale].upload = 'http:' + file.url
        return newFile
      },


### PR DESCRIPTION
This PR fixes the error when trying to import an asset with `uploadFrom` and `upload` fields at the same time. The fix is a workaround until the backend fixes the payload issue 