### PR TITLE
fix(webhooks): Workaround webhooks with credentials issue

### DIFF
--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -16,6 +16,10 @@ export function entries (entry) {
 }
 
 export function webhooks (webhook) {
+  // Workaround for webhooks with credentials 
+  if (webhook.httpBasicUsername) {
+    delete webhook.httpBasicUsername
+  }
   return webhook
 }
 


### PR DESCRIPTION
This PR is a workaround to avoid breaking the import process when importing webhooks with credential which is not possible since the exported payload will contain only the username and not the password due to security measures in the CMA API. The CMA will return a validation error which we can avoid by removing the username field and the user can refill the credential again once everything is imported