### PR TITLE
Fix module exports across project

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,9 @@
-export { default as utils } from './utils'
-export { default as get } from './get'
-export { default as push } from './push'
-export { default as transform } from './transform'
+import * as utils from './utils'
+import * as get from './get'
+import * as push from './push'
+import * as transform from './transform'
+
+export { utils }
+export { get }
+export { push }
+export { transform }

--- a/lib/push/index.js
+++ b/lib/push/index.js
@@ -1,6 +1,12 @@
-export { default as assets } from './assets'
-export { default as creation } from './creation'
-export { default as deletion } from './deletion'
-export { default as publishing } from './publishing'
+import * as assets from './assets'
+import * as creation from './creation'
+import * as deletion from './deletion'
+import * as publishing from './publishing'
+
+export { assets }
+export { creation }
+export { deletion }
+export { publishing }
+
 export { default as getEntityName } from './get-entity-name'
 export { default as pushToSpace } from './push-to-space'

--- a/lib/transform/index.js
+++ b/lib/transform/index.js
@@ -1,2 +1,4 @@
-export { default as transformers } from './transformers'
+import * as transformers from './transformers'
+
+export { transformers }
 export { default as transformSpace } from './transform-space'


### PR DESCRIPTION
You guys broke pretty much all your exports with 76a790884a4c0da6ab9b5a7d6a08af205db3eca8 😳

A lot of the modules in this project don't have a default export and yet you re-exported a default export from them. This caused the members of the main module to be `undefined` after the babel transpilation process.

Took me pretty much all day to figure out it was the library and not some weird node dependency quirk on my system ಠ_ಠ

How did this get into master? 😞 