### PR TITLE
add editor interface filter for old content types

### DIFF
--- a/lib/get/get-full-source-space.js
+++ b/lib/get/get-full-source-space.js
@@ -61,7 +61,9 @@ Full error details below.
       task: (ctx) => {
         return getEditorInterfaces(ctx.data.contentTypes)
         .then((editorInterfaces) => {
-          ctx.data.editorInterfaces = editorInterfaces
+          ctx.data.editorInterfaces = editorInterfaces.filter((editorInterface) => {
+            return editorInterface !== null
+          })
         })
       },
       skip: (ctx) => skipContentModel || (ctx.data.contentTypes.length === 0 && 'Skipped since no content types downloaded')


### PR DESCRIPTION
Some old content types do not have a editor interface. Also unpublished ones do not have.

This fixes https://github.com/contentful/contentful-import/issues/35