### PR TITLE
Skip empty/null/undefined entries during creation

### DIFF
--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -14,6 +14,7 @@ import errorBuffer from '../utils/error-buffer'
  */
 export function createEntities (context, entities, destinationEntities) {
   return Promise.map(entities, (entity) => {
+    if (isEmpty(entity.transformed)) { return null }
     const destinationEntity = getDestinationEntityForSourceEntity(destinationEntities, entity.transformed)
     const operation = destinationEntity ? 'update' : 'create'
     const promise = destinationEntity

--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -2,6 +2,7 @@ import Promise from 'bluebird'
 import log from 'npmlog'
 import {partial} from 'lodash/function'
 import {find} from 'lodash/collection'
+import {isEmpty} from 'lodash/lang'
 import {assign, get, omitBy, omit} from 'lodash/object'
 import getEntityName from './get-entity-name'
 import errorBuffer from '../utils/error-buffer'
@@ -34,6 +35,7 @@ export function createEntries (context, entries, destinationEntries) {
 }
 
 function createEntry (entry, space, skipContentModel, destinationEntries) {
+  if (isEmpty(entry.transformed)) { return null }
   const contentTypeId = entry.original.sys.contentType.sys.id
   const destinationEntry = getDestinationEntityForSourceEntity(
     destinationEntries, entry.transformed)


### PR DESCRIPTION
I ran into an issue where the collection of transformed entries contained `null` values. This causes the creation function to fail here:

```javascript
function createEntryInDestination (space, contentTypeId, sourceEntity) {
  const id = sourceEntity.sys.id // fails
  const plainData = getPlainData(sourceEntity)
  return space.createEntryWithId(contentTypeId, id, plainData)
}
```

Of course part of the problem is that `sys.id` is accessed in an unsafe manner. However, even if you fix that with something like `_.get`, the call to `getPlainData()` will fail.

So in the end I just early-return null whenever the `transformed` entity/entry is null.

This still does not seem like the cleanest approach to me. Maybe you have a better idea, for example rejecting any null values from the collection in `transform-space.js`:

```
export default function (
  space, destinationSpace, customTransformers, entities = spaceEntities
) {
  const transformers = defaults(customTransformers, defaultTransformers)
  // TODO maybe we don't need promises here at all
  const newSpace = omit(space, ...entities)
  return Promise.reduce(entities, (newSpace, type) => {
    // Remove null values somewhere in this chain.
    return Promise.map(
      space[type],
      (entity) => Promise.resolve({
        original: entity,
        transformed: transformers[type](entity, destinationSpace[type])
      })
    )
      .then((entities) => {
        newSpace[type] = entities
        return newSpace
      })
  }, newSpace)
}
```

WDYT?