### PR TITLE
add publishing queue to retry unresolvable publish actions

### DIFF
--- a/lib/push/publishing.js
+++ b/lib/push/publishing.js
@@ -3,26 +3,66 @@ import log from 'npmlog'
 import getEntityName from './get-entity-name'
 import errorBuffer from '../utils/error-buffer'
 
+function runQueue (queue, result) {
+  if (!result) {
+    result = []
+  }
+  queue = queue.filter((entity) => {
+    if (!entity || !entity.publish) {
+      log.info('Error while publishing entity: Unable to parse entity')
+      log.info(`Unparseable entity: ${JSON.stringify(entity, null, 0)}`)
+      return false
+    }
+    return true
+  })
+  log.info(`Starting new publishing queue: ${queue.map((entity) => entity.sys.id).join(', ')}`)
+  return Promise.map(queue, (entity, index) => {
+    return entity.publish()
+      .then((entity) => {
+        log.info(`Published ${entity.sys.type} ${getEntityName(entity)}`)
+        result.push(entity)
+        return null
+      }, (err) => {
+        errorBuffer.push(err)
+        const apiError = JSON.parse(err.message)
+        const errors = apiError.details.errors || []
+        if (apiError.status === 422 && errors.findIndex((error) => error.name === 'notResolvable') !== -1) {
+          log.info(`Unable to resolve ${entity.sys.id} (${(getEntityName(entity))})`)
+          return entity
+        }
+        log.info(`Failed to publish ${entity.sys.id} (${(getEntityName(entity))})`)
+        return null
+      })
+  }, {concurrency: 1})
+  .then((entities) => entities.filter((entity) => entity))
+  .then((entities) => {
+    if (entities.length > 0) {
+      log.info(`Found ${entities.length} unpublished entities`)
+      return runQueue(entities, result)
+    }
+    return result
+  })
+}
+
 /**
  * Publish a list of entities.
  * Does not return a rejected promise in the case of an error, pushing it
  * to an error buffer instead.
  */
 export function publishEntities (entities) {
-  return Promise.map(entities, (entity, index) => {
-    if (!entity || !entity.publish) {
-      log.info('Error While publishing entity: undefined entity at index ' + index)
-      return Promise.resolve(entity)
-    }
-    return entity.publish()
-      .then((entity) => {
-        log.info(`Published ${entity.sys.type} ${getEntityName(entity)}`)
-        return entity
-      }, (err) => {
-        errorBuffer.push(err)
-        return entity
-      })
-  }, {concurrency: 6})
+  if (entities.length === 0) {
+    log.info(`Skip publishing since zero entities passed`)
+    return entities
+  }
+  const entity = entities[0].original || entities[0]
+  const type = entity.sys.type || 'unknown type'
+  log.info(`Starting publishing ${entities.length} ${type}s`)
+
+  return runQueue(entities)
+  .then((result) => {
+    log.info(`Finished publishing ${entities.length} ${type}s. Returning ${result.length} entities`)
+    return result
+  })
 }
 
 /**


### PR DESCRIPTION
Fixes:
* Publishing of linked entities by re-queueing unresolvable ones
* https://github.com/contentful/contentful-import/issues/7
* might fix (some?) issues in here https://github.com/contentful/contentful-import/issues/36
* Some other users problems

Does not fix:
* Circular dependencies