### PR TITLE
fix(creation): Add concurrency for entris creation

### DIFF
--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -29,8 +29,9 @@ export function createEntities (context, entities, destinationEntities) {
  */
 export function createEntries (context, entries, destinationEntries) {
   return Promise.map(entries, (entry) => createEntry(
-    entry, context.space, context.skipContentModel, destinationEntries)
-  ).then((entries) => entries.filter((entry) => entry))
+    entry, context.space, context.skipContentModel, destinationEntries),
+    {concurrency: 6})
+    .then((entries) => entries.filter((entry) => entry))
 }
 
 function createEntry (entry, space, skipContentModel, destinationEntries) {


### PR DESCRIPTION
This PR adds concurrency when creating entries, 😱  concurrency was unlimited before which is not good for rate limiting

👇  tested in with contentful-import and all is fine
![screen shot 2017-05-22 at 11 40 45](https://cloud.githubusercontent.com/assets/1156093/26302130/8a95abf6-3ee3-11e7-92cf-25020a487430.png)
