### PR TITLE
fix(creation): Use createEntry when id is not provided

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,8 @@
 {
   "presets": [
     ["env", {
-      "debug": true,
       "targets": {
-        "node": 4.7
+        "node": "4.7"
       }
     }]
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/node,windows,osx,linux,vim
+yarn.lock
+package-lock.json

--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -65,7 +65,9 @@ function createInDestination (context, sourceEntity) {
 function createEntryInDestination (space, contentTypeId, sourceEntity) {
   const id = sourceEntity.sys.id
   const plainData = getPlainData(sourceEntity)
-  return space.createEntryWithId(contentTypeId, id, plainData)
+  return id
+    ? space.createEntryWithId(contentTypeId, id, plainData)
+    : space.createEntry(contentTypeId, plainData)
 }
 
 /**

--- a/test/push/creation-test.js
+++ b/test/push/creation-test.js
@@ -43,20 +43,23 @@ test('Create entries', (t) => {
   setup()
   const updateStub = sinon.stub().returns(Promise.resolve({sys: {type: 'Entry'}}))
   const space = {
-    createEntryWithId: sinon.stub().returns(Promise.resolve({sys: {type: 'Entry'}}))
+    createEntryWithId: sinon.stub().returns(Promise.resolve({sys: {type: 'Entry'}})),
+    createEntry: sinon.stub().returns(Promise.resolve({sys: {type: 'Entry'}}))
   }
   const entries = [
     { original: { sys: {contentType: {sys: {id: 'ctid'}}} }, transformed: { sys: {id: '123'} } },
-    { original: { sys: {contentType: {sys: {id: 'ctid'}}} }, transformed: { sys: {id: '456'} } }
+    { original: { sys: {contentType: {sys: {id: 'ctid'}}} }, transformed: { sys: {id: '456'} } },
+    { original: { sys: {contentType: {sys: {id: 'ctid'}}} }, transformed: { sys: {} } }
   ]
   const destinationEntries = [
     {sys: {id: '123', version: 6}, update: updateStub}
   ]
   createEntries({space: space, skipContentModel: false}, entries, destinationEntries)
   .then((response) => {
-    t.equals(space.createEntryWithId.callCount, 1, 'create entries')
+    t.equals(space.createEntryWithId.callCount, 1, 'create entries with the same id')
+    t.equals(space.createEntry.callCount, 1, 'create entries even when the id is not provided')
     t.equals(updateStub.callCount, 1, 'update entries')
-    t.equals(logMock.info.callCount, 2, 'logs creation of two entries')
+    t.equals(logMock.info.callCount, 3, 'logs creation of two entries')
     teardown()
     t.end()
   })


### PR DESCRIPTION
when you provide a content-file that does not contain an entry id, the import tool still uses `space.createEntryWithId` which results in entry created with id `undefined`