### PR TITLE
fix(existing-content): paginate in the existing content check

### DIFF
--- a/lib/get/get-outdated-destination-content.js
+++ b/lib/get/get-outdated-destination-content.js
@@ -11,18 +11,47 @@ const BATCH_SIZE_LIMIT = 100
  * Only the supplied entry/asset IDs will be retrieved. All contentTypes
  * and Locales will be retrieved.
  */
-export default function getOutdatedDestinationContent ({managementClient, spaceId, entryIds = [], assetIds = [], webhookIds = [], skipContentModel, skipContent}) {
+export default function getOutdatedDestinationContent ({
+  managementClient,
+  spaceId,
+  sourceResponse,
+  contentModelOnly,
+  skipLocales,
+  skipContentModel
+}) {
   log.info('Checking if destination space already has any content and retrieving it')
 
   return managementClient.getSpace(spaceId)
     .then((space) => {
-      return Promise.props({
-        contentTypes: skipContentModel ? Promise.resolve([]) : space.getContentTypes().then(extractItems),
-        entries: skipContent ? Promise.resolve([]) : batchedIdQuery(space, 'getEntries', entryIds),
-        assets: skipContent ? Promise.resolve([]) : batchedIdQuery(space, 'getAssets', assetIds),
-        locales: skipContentModel ? Promise.resolve([]) : space.getLocales().then(extractItems),
-        webhooks: []
-      })
+      const result = {}
+      const sourceContent = {
+        contentTypes: sourceResponse.contentTypes || [],
+        locales: sourceResponse.locales || [],
+        entries: sourceResponse.entries || [],
+        assets: sourceResponse.assets || []
+      }
+
+      if (!skipContentModel) {
+        const contentTypeIds = sourceContent.contentTypes.map((e) => e.sys.id)
+        result.contentTypes = batchedIdQuery(space, 'getContentTypes', contentTypeIds)
+
+        if (!skipLocales) {
+          const localeIds = sourceContent.locales.map((e) => e.sys.id)
+          result.locales = batchedIdQuery(space, 'getLocales', localeIds)
+        }
+      }
+
+      if (contentModelOnly) {
+        return Promise.props(result)
+      }
+
+      const entryIds = sourceContent.entries.map((e) => e.sys.id)
+      const assetIds = sourceContent.assets.map((e) => e.sys.id)
+      result.entries = batchedIdQuery(space, 'getEntries', entryIds)
+      result.assets = batchedIdQuery(space, 'getAssets', assetIds)
+      result.webhooks = []
+
+      return Promise.props(result)
     }, (err) => {
       log.error(`
 The destination space was not found. This can happen for multiple reasons:
@@ -46,10 +75,6 @@ function batchedIdQuery (space, method, ids) {
         return fullResponse
       })
   }, [])
-}
-
-function extractItems (response) {
-  return response.items
 }
 
 function getIdBatches (ids) {

--- a/test/get/get-outdated-destination-content-test.js
+++ b/test/get/get-outdated-destination-content-test.js
@@ -5,8 +5,11 @@ import {times} from 'lodash/util'
 
 import getOutdatedDestinationContent from '../../lib/get/get-outdated-destination-content'
 
-const sourceEntryIds = times(2000, (n) => `e-${n}`)
-const sourceAssetIds = times(1500, (n) => `a-${n}`)
+const sourceResponse = {
+  contentTypes: times(150, (n) => ({sys: {id: `ct-${n}`}})),
+  entries: times(2000, (n) => ({sys: {id: `e-${n}`}})),
+  assets: times(1500, (n) => ({sys: {id: `a-${n}`}}))
+}
 
 const logMock = {
   info: sinon.stub(),
@@ -39,8 +42,7 @@ test('Gets destination content', (t) => {
   getOutdatedDestinationContent({
     managementClient: mockClient,
     spaceId: 'spaceid',
-    entryIds: sourceEntryIds,
-    assetIds: sourceAssetIds
+    sourceResponse
   })
   .then((response) => {
     t.equals(mockSpace.getEntries.callCount, 20, 'getEntries is split into multiple calls')
@@ -73,8 +75,7 @@ test('Fails to get destination space', (t) => {
   getOutdatedDestinationContent({
     managementClient: mockClient,
     spaceId: 'spaceid',
-    entryIds: sourceEntryIds,
-    assetIds: sourceAssetIds
+    sourceResponse
   })
   .catch((err) => {
     t.ok(err.name === 'NotFound')


### PR DESCRIPTION
instead of passing some flags and id's, I now pass the whole `sourceResponse` (aka the content file content), use batchedIdQueries on all entity types and generate the id's on the fly when it is needed. Will also save a little performance.