### PR TITLE
Fix/asset publishing

### DIFF
--- a/lib/push/creation.js
+++ b/lib/push/creation.js
@@ -100,10 +100,7 @@ function handleEntryCreationErrors (entry, space, skipContentModel, destinationE
     entry.transformed.fields = cleanupUnknownFields(entry.transformed.fields, errors)
     return createEntry(entry, space, skipContentModel, destinationEntries)
   }
-  err.originalEntry = entry.original
-  err.transformedEntry = entry.transformed
-  err.contentModelWasSkipped = skipContentModel
-  err.entity = entry.original
+  err.entity = entry
   logEmitter.emit('error', err)
 
   // No need to pass this entry down to publishing if it wasn't created

--- a/lib/push/publishing.js
+++ b/lib/push/publishing.js
@@ -43,6 +43,7 @@ function runQueue (queue, result) {
       .then((entity) => {
         return entity
       }, (err) => {
+        err.entity = entity
         logEmitter.emit('error', err)
         return null
       })

--- a/lib/push/push-to-space.js
+++ b/lib/push/push-to-space.js
@@ -135,6 +135,10 @@ export default function pushToSpace ({
                   ctEditorInterface.controls = editorInterface.controls
                   return ctEditorInterface.update()
                 })
+                .catch((err) => {
+                  err.entity = editorInterface
+                  throw err
+                })
             }
           }
           return Promise.resolve()

--- a/lib/push/push-to-space.js
+++ b/lib/push/push-to-space.js
@@ -104,6 +104,7 @@ export default function pushToSpace ({
           sourceContent.contentTypes,
           destinationContent.contentTypes
         )
+          .then(removeEmptyEntities)
           .then((contentTypes) => {
             ctx.data.contentTypes = contentTypes
             teardownTaskListeners()
@@ -117,7 +118,15 @@ export default function pushToSpace ({
     },
     {
       title: 'Publishing Content Types',
-      task: createPublishTask('contentTypes', sourceContent),
+      task: (ctx, task) => {
+        const teardownTaskListeners = logToTaskOutput(task)
+        return publishEntities(ctx, task, ctx.data.contentTypes, sourceContent.contentTypes)
+          .then(removeEmptyEntities)
+          .then((contentTypes) => {
+            ctx.data.contentTypes = contentTypes
+            teardownTaskListeners()
+          })
+      },
       skip: (ctx) => skipContentModel
     },
     {
@@ -144,6 +153,7 @@ export default function pushToSpace ({
           return Promise.resolve()
         })
         return Promise.all(contentTypesWithEditorInterface)
+          .then(removeEmptyEntities)
           .then((editorInterfaces) => {
             ctx.data.editorInterfaces = editorInterfaces
             teardownTaskListeners()
@@ -161,12 +171,11 @@ export default function pushToSpace ({
           sourceContent.assets,
           destinationContent.assets
         )
-          .then((assets) => {
-            return assets.filter((asset) => asset !== null)
-          })
+          .then(removeEmptyEntities)
           .then((assetsToProcess) => {
             return assets.processAssets(assetsToProcess)
           })
+          .then(removeEmptyEntities)
           .then((assets) => {
             ctx.data.assets = assets
             teardownTaskListeners()
@@ -180,7 +189,15 @@ export default function pushToSpace ({
     },
     {
       title: 'Publishing Assets',
-      task: createPublishTask('assets', sourceContent),
+      task: (ctx, task) => {
+        const teardownTaskListeners = logToTaskOutput(task)
+        return publishEntities(ctx, task, ctx.data.assets, sourceContent.assets)
+          .then(removeEmptyEntities)
+          .then((assets) => {
+            ctx.data.assets = assets
+            teardownTaskListeners()
+          })
+      },
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
@@ -193,9 +210,7 @@ export default function pushToSpace ({
           sourceContent.entries,
           destinationContent.entries
         )
-          .then((entries) => {
-            return entries.filter((entry) => entry !== null)
-          })
+          .then(removeEmptyEntities)
           .then((entries) => {
             ctx.data.entries = entries
             teardownTaskListeners()
@@ -209,7 +224,15 @@ export default function pushToSpace ({
     },
     {
       title: 'Publishing Content Entries',
-      task: createPublishTask('entries', sourceContent),
+      task: (ctx, task) => {
+        const teardownTaskListeners = logToTaskOutput(task)
+        return publishEntities(ctx, task, ctx.data.entries, sourceContent.entries)
+          .then(removeEmptyEntities)
+          .then((entries) => {
+            ctx.data.entries = entries
+            teardownTaskListeners()
+          })
+      },
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
@@ -222,9 +245,7 @@ export default function pushToSpace ({
           sourceContent.webhooks,
           destinationContent.webhooks
         )
-          .then((webhooks) => {
-            return webhooks.filter((webhook) => webhook !== null)
-          })
+          .then(removeEmptyEntities)
           .then((webhooks) => {
             ctx.data.webhooks = webhooks
             teardownTaskListeners()
@@ -235,18 +256,21 @@ export default function pushToSpace ({
   ], listrOptions)
 }
 
-function createPublishTask (type, sourceContent) {
-  return (ctx, task) => {
-    const teardownTaskListeners = logToTaskOutput(task)
+// In case some entity throws an error, we null it in the list to avoid further processing.
+// This functions removes the nulled entities from the lists.
+function removeEmptyEntities (entityList) {
+  return entityList.filter((entity) => entity !== null)
+}
 
-    const entityIdsToPublish = sourceContent[type]
-      .filter(({original}) => original.sys.publishedVersion)
-      .map((entity) => entity.original.sys.id)
+function publishEntities (ctx, task, entities, sourceEntities) {
+  // Find all entities in source content which are published
+  const entityIdsToPublish = sourceEntities
+    .filter(({original}) => original.sys.publishedVersion)
+    .map(({original}) => original.sys.id)
 
-    const entitiesToPublish = ctx.data[type]
-      .filter((entity) => entityIdsToPublish.includes(entity.sys.id))
+  // Filter imported entities and publish only these who got published in the source
+  const entitiesToPublish = entities
+    .filter((entity) => entityIdsToPublish.includes(entity.sys.id))
 
-    return publishing.publishEntities(entitiesToPublish)
-      .then(teardownTaskListeners)
-  }
+  return publishing.publishEntities(entitiesToPublish)
 }

--- a/lib/push/push-to-space.js
+++ b/lib/push/push-to-space.js
@@ -135,7 +135,7 @@ export default function pushToSpace ({
         const teardownTaskListeners = logToTaskOutput(task)
 
         let contentTypesWithEditorInterface = ctx.data.contentTypes.map((contentType) => {
-          // @todo -> potential bug: only exports on editorinterface, multiple possible?
+          // @todo -> potential bug: only exports one editorinterface, multiple possible?
           for (let editorInterface of sourceContent.editorInterfaces) {
             if (editorInterface.sys.contentType.sys.id === contentType.sys.id) {
               return ctx.space.getEditorInterfaceForContentType(contentType.sys.id)

--- a/lib/push/push-to-space.js
+++ b/lib/push/push-to-space.js
@@ -215,7 +215,7 @@ export default function pushToSpace ({
             ctx.data.entries = entries
             teardownTaskListeners()
 
-            if (assets.length < 5) {
+            if (entries.length < 5) {
               return Promise.delay(prePublishDelay)
             }
           })

--- a/lib/utils/get-entity-name.js
+++ b/lib/utils/get-entity-name.js
@@ -12,6 +12,12 @@ export default function getEntityName (entity) {
     return attachId(titleField[locales[0]], entity)
   }
 
+  const nameField = get(entity, 'fields.name')
+  if (nameField) {
+    const locales = Object.keys(nameField)
+    return attachId(nameField[locales[0]], entity)
+  }
+
   const id = get(entity, 'sys.id')
   if (id) {
     return id

--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -80,6 +80,13 @@ export function formatLogMessageLogfile (logMessage) {
       logMessage.error.stacktrace = logMessage.error.stack.toString().split(/\n +at /)
     }
   }
+
+  // Listr attaches the whole context to error messages.
+  // Remove it to avoid error log file pollution.
+  if (typeof logMessage.error === 'object' && 'context' in logMessage.error) {
+    delete logMessage.error.context
+  }
+
   return logMessage
 }
 


### PR DESCRIPTION
* when entity import/processing errored, publishing failed since it used the source content instead of the result of the import leading to publishing of entities which got not imported
* filtering of nulled entities was incomplete, leading to function calls on null `null.processAllLocales()` :man_facepalming: 
* errors thrown within a listr task get the listr context attached. Since we heavily used it, that spammed the error log. This is now excluded, turning the error log in a human readable format.

Does not include but worth mentioning:
already pushed a fix to next in import & batch libs which downloads the destination content again