### PR TITLE
updating contentful management version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bluebird": "^3.3.3",
     "contentful": "^4.3.0",
-    "contentful-management": "^3.7.6",
+    "contentful-management": "^4.0.3",
     "listr": "^0.11.0",
     "listr-verbose-renderer": "^0.4.0",
     "lodash": "^4.0.1",


### PR DESCRIPTION
There have been several bug fixes in Contentful management since the 3.7.6 release, [one of which](https://github.com/contentful/contentful-management.js/releases/tag/v4.0.2) is required to unblock me 