### PR TITLE
fix: check if an asset exists before processing

### DIFF
--- a/lib/push/assets.js
+++ b/lib/push/assets.js
@@ -6,10 +6,15 @@ import { logEmitter } from '../utils/logging'
 export function processAssets (assets) {
   return Promise.map(assets, (asset) => {
     logEmitter.emit('info', `Processing Asset ${getEntityName(asset)}`)
-    return asset.processForAllLocales().catch((err) => {
-      err.entity = asset
-      logEmitter.emit('error', err)
-      return Promise.resolve(null)
-    })
+    if (asset) {
+      return asset.processForAllLocales().catch((err) => {
+        err.entity = asset
+        logEmitter.emit('error', err)
+        return Promise.resolve(null)
+      })
+    }
+    logEmitter.emit('warning', 'Falsy asset, skipping...')
+    return Promise.resolve(null)
+    
   }, {concurrency: 4})
 }

--- a/lib/push/assets.js
+++ b/lib/push/assets.js
@@ -15,6 +15,5 @@ export function processAssets (assets) {
     }
     logEmitter.emit('warning', 'Falsy asset, skipping...')
     return Promise.resolve(null)
-    
   }, {concurrency: 4})
 }


### PR DESCRIPTION
Hi, 

I'm using `contentful-import@next` with `contentful-batch-libs@next` and I have occasionally errors with assets that are `null` during the `processAssets` task.

So I come up with a simple solution: checking if an asset exists before calling `processForAllLocales()` method.

Vincenzo