### PR TITLE
fix(errors): failing tasks now use human readable error format

### DIFF
--- a/lib/get/get-full-source-space.js
+++ b/lib/get/get-full-source-space.js
@@ -9,25 +9,27 @@ const MAX_ALLOWED_LIMIT = 1000
 let pageLimit = MAX_ALLOWED_LIMIT
 
 // Set up log listening form SDK and proper catching and throwing of SDK errors
-function wrapTask (ctx, task, func) {
-  const teardownTaskListeners = logToTaskOutput(task)
-  return func(ctx, task)
-    .then(() => {
-      teardownTaskListeners()
-    })
-    .catch((error) => {
-      // Format message for listr output
-      const formattedMessage = formatLogMessageOneLine({
-        ts: (new Date()).toJSON(),
-        level: 'error',
-        error
+function wrapTask (func) {
+  return (ctx, task) => {
+    const teardownTaskListeners = logToTaskOutput(task)
+    return func(ctx, task)
+      .then(() => {
+        teardownTaskListeners()
       })
-      const enrichedError = new Error(formattedMessage)
+      .catch((error) => {
+        // Format message for listr output
+        const formattedMessage = formatLogMessageOneLine({
+          ts: (new Date()).toJSON(),
+          level: 'error',
+          error
+        })
+        const enrichedError = new Error(formattedMessage)
 
-      // Attach original error object for error log
-      enrichedError.originalError = error
-      throw enrichedError
-    })
+        // Attach original error object for error log
+        enrichedError.originalError = error
+        throw enrichedError
+      })
+  }
 }
 
 /**
@@ -67,7 +69,7 @@ export default function getFullSourceSpace ({
     },
     {
       title: 'Fetching content types data',
-      task: (ctx, task) => wrapTask(ctx, task, (ctx, task) => {
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getContentTypes'})
           .then(extractItems)
           .then((items) => {

--- a/lib/get/get-full-source-space.js
+++ b/lib/get/get-full-source-space.js
@@ -2,11 +2,33 @@ import Promise from 'bluebird'
 import Listr from 'listr'
 import verboseRenderer from 'listr-verbose-renderer'
 
-import { logEmitter, logToTaskOutput } from '../utils/logging'
+import { logEmitter, logToTaskOutput, formatLogMessageOneLine } from '../utils/logging'
 import sortEntries from '../utils/sort-entries'
 
 const MAX_ALLOWED_LIMIT = 1000
 let pageLimit = MAX_ALLOWED_LIMIT
+
+// Set up log listening form SDK and proper catching and throwing of SDK errors
+function wrapTask (ctx, task, func) {
+  const teardownTaskListeners = logToTaskOutput(task)
+  return func(ctx, task)
+    .then(() => {
+      teardownTaskListeners()
+    })
+    .catch((error) => {
+      // Format message for listr output
+      const formattedMessage = formatLogMessageOneLine({
+        ts: (new Date()).toJSON(),
+        level: 'error',
+        error
+      })
+      const enrichedError = new Error(formattedMessage)
+
+      // Attach original error object for error log
+      enrichedError.originalError = error
+      throw enrichedError
+    })
+}
 
 /**
  * Gets all the content from a space via the management API. This includes
@@ -45,15 +67,13 @@ export default function getFullSourceSpace ({
     },
     {
       title: 'Fetching content types data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: (ctx, task) => wrapTask(ctx, task, (ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getContentTypes'})
           .then(extractItems)
           .then((items) => {
             ctx.data.contentTypes = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipContentModel
     },
     {

--- a/lib/get/get-full-source-space.js
+++ b/lib/get/get-full-source-space.js
@@ -2,35 +2,12 @@ import Promise from 'bluebird'
 import Listr from 'listr'
 import verboseRenderer from 'listr-verbose-renderer'
 
-import { logEmitter, logToTaskOutput, formatLogMessageOneLine } from '../utils/logging'
+import { logEmitter } from '../utils/logging'
+import { wrapTask } from '../utils/listr'
 import sortEntries from '../utils/sort-entries'
 
 const MAX_ALLOWED_LIMIT = 1000
 let pageLimit = MAX_ALLOWED_LIMIT
-
-// Set up log listening form SDK and proper catching and throwing of SDK errors
-function wrapTask (func) {
-  return (ctx, task) => {
-    const teardownTaskListeners = logToTaskOutput(task)
-    return func(ctx, task)
-      .then(() => {
-        teardownTaskListeners()
-      })
-      .catch((error) => {
-        // Format message for listr output
-        const formattedMessage = formatLogMessageOneLine({
-          ts: (new Date()).toJSON(),
-          level: 'error',
-          error
-        })
-        const enrichedError = new Error(formattedMessage)
-
-        // Attach original error object for error log
-        enrichedError.originalError = error
-        throw enrichedError
-      })
-  }
-}
 
 /**
  * Gets all the content from a space via the management API. This includes
@@ -58,14 +35,12 @@ export default function getFullSourceSpace ({
   return new Listr([
     {
       title: 'Connecting to space',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return managementClient.getSpace(spaceId)
           .then((space) => {
             ctx.space = space
-            teardownTaskListeners()
           })
-      }
+      })
     },
     {
       title: 'Fetching content types data',
@@ -80,83 +55,71 @@ export default function getFullSourceSpace ({
     },
     {
       title: 'Fetching editor interfaces data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return getEditorInterfaces(ctx.data.contentTypes)
           .then((editorInterfaces) => {
             ctx.data.editorInterfaces = editorInterfaces.filter((editorInterface) => {
               return editorInterface !== null
             })
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => skipContentModel || (ctx.data.contentTypes.length === 0 && 'Skipped since no content types downloaded')
     },
     {
       title: 'Fetching content entries data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getEntries', query: queryEntries})
           .then(extractItems)
           .then(sortEntries)
           .then((items) => filterDrafts(items, includeDrafts))
           .then((items) => {
             ctx.data.entries = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipContent
     },
     {
       title: 'Fetching assets data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getAssets', query: queryAssets})
           .then(extractItems)
           .then((items) => {
             ctx.data.assets = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipContent
     },
     {
       title: 'Fetching locales data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getLocales'})
           .then(extractItems)
           .then((items) => {
             ctx.data.locales = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipContentModel
     },
     {
       title: 'Fetching webhooks data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getWebhooks'})
           .then(extractItems)
           .then((items) => {
             ctx.data.webhooks = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipWebhooks
     },
     {
       title: 'Fetching roles data',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return pagedGet({space: ctx.space, method: 'getRoles'})
           .then(extractItems)
           .then((items) => {
             ctx.data.roles = items
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipRoles
     }
   ], listrOptions)

--- a/lib/push/push-to-space.js
+++ b/lib/push/push-to-space.js
@@ -5,7 +5,8 @@ import verboseRenderer from 'listr-verbose-renderer'
 
 import * as assets from './assets'
 import * as creation from './creation'
-import { logEmitter, logToTaskOutput } from '../utils/logging'
+import { logEmitter } from '../utils/logging'
+import { wrapTask } from '../utils/listr'
 import * as publishing from './publishing'
 
 const DEFAULT_CONTENT_STRUCTURE = {
@@ -70,19 +71,16 @@ export default function pushToSpace ({
   return new Listr([
     {
       title: 'Connecting to space',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return managementClient.getSpace(spaceId)
           .then((space) => {
             ctx.space = space
-            teardownTaskListeners()
           })
-      }
+      })
     },
     {
       title: 'Importing Locales',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return creation.createEntities(
           { space: ctx.space, type: 'Locale' },
           sourceContent.locales,
@@ -90,15 +88,13 @@ export default function pushToSpace ({
         )
           .then((locales) => {
             ctx.data.locales = locales
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: () => skipContentModel || skipLocales
     },
     {
       title: 'Importing Content Types',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return creation.createEntities(
           {space: ctx.space, type: 'ContentType'},
           sourceContent.contentTypes,
@@ -107,33 +103,28 @@ export default function pushToSpace ({
           .then(removeEmptyEntities)
           .then((contentTypes) => {
             ctx.data.contentTypes = contentTypes
-            teardownTaskListeners()
 
             if (contentTypes.length < 5) {
               return Promise.delay(prePublishDelay)
             }
           })
-      },
+      }),
       skip: () => skipContentModel
     },
     {
       title: 'Publishing Content Types',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return publishEntities(ctx, task, ctx.data.contentTypes, sourceContent.contentTypes)
           .then(removeEmptyEntities)
           .then((contentTypes) => {
             ctx.data.contentTypes = contentTypes
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => skipContentModel
     },
     {
       title: 'Importing Editor Interfaces',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
-
+      task: wrapTask((ctx, task) => {
         let contentTypesWithEditorInterface = ctx.data.contentTypes.map((contentType) => {
           for (let editorInterface of sourceContent.editorInterfaces) {
             if (editorInterface.sys.contentType.sys.id === contentType.sys.id) {
@@ -155,16 +146,13 @@ export default function pushToSpace ({
           .then(removeEmptyEntities)
           .then((editorInterfaces) => {
             ctx.data.editorInterfaces = editorInterfaces
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => skipContentModel || ctx.data.contentTypes.length === 0
     },
     {
       title: 'Importing Assets',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
-
+      task: wrapTask((ctx, task) => {
         return creation.createEntities(
           {space: ctx.space, type: 'Asset'},
           sourceContent.assets,
@@ -177,46 +165,39 @@ export default function pushToSpace ({
           .then(removeEmptyEntities)
           .then((assets) => {
             ctx.data.assets = assets
-            teardownTaskListeners()
 
             if (assets.length < 5) {
               return Promise.delay(prePublishDelay)
             }
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly
     },
     {
       title: 'Publishing Assets',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return publishEntities(ctx, task, ctx.data.assets, sourceContent.assets)
           .then(removeEmptyEntities)
           .then((assets) => {
             ctx.data.publishedAssets = assets
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
       title: 'Archiving Assets',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return archiveEntities(ctx, task, ctx.data.assets, sourceContent.assets)
           .then(removeEmptyEntities)
           .then((assets) => {
             ctx.data.archivedAssets = assets
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
       title: 'Importing Content Entries',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
-
+      task: wrapTask((ctx, task) => {
         return creation.createEntries(
           {space: ctx.space, skipContentModel},
           sourceContent.entries,
@@ -225,46 +206,39 @@ export default function pushToSpace ({
           .then(removeEmptyEntities)
           .then((entries) => {
             ctx.data.entries = entries
-            teardownTaskListeners()
 
             if (entries.length < 5) {
               return Promise.delay(prePublishDelay)
             }
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly
     },
     {
       title: 'Publishing Content Entries',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return publishEntities(ctx, task, ctx.data.entries, sourceContent.entries)
           .then(removeEmptyEntities)
           .then((entries) => {
             ctx.data.publishedEntries = entries
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
       title: 'Archiving Entries',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
+      task: wrapTask((ctx, task) => {
         return archiveEntities(ctx, task, ctx.data.entries, sourceContent.entries)
           .then(removeEmptyEntities)
           .then((entries) => {
             ctx.data.archivedEntries = entries
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly || skipContentPublishing
     },
     {
       title: 'Creating Web Hooks',
-      task: (ctx, task) => {
-        const teardownTaskListeners = logToTaskOutput(task)
-
+      task: wrapTask((ctx, task) => {
         return creation.createEntities(
           {space: ctx.space, type: 'Webhook'},
           sourceContent.webhooks,
@@ -273,9 +247,8 @@ export default function pushToSpace ({
           .then(removeEmptyEntities)
           .then((webhooks) => {
             ctx.data.webhooks = webhooks
-            teardownTaskListeners()
           })
-      },
+      }),
       skip: (ctx) => contentModelOnly
     }
   ], listrOptions)

--- a/lib/utils/listr.js
+++ b/lib/utils/listr.js
@@ -1,0 +1,26 @@
+import { logToTaskOutput, formatLogMessageOneLine } from '../utils/logging'
+
+// Set up log listening form SDK and proper catching and throwing of SDK errors
+export function wrapTask (func) {
+  return (ctx, task) => {
+    const teardownTaskListeners = logToTaskOutput(task)
+    return func(ctx, task)
+      .then(() => {
+        teardownTaskListeners()
+      })
+      .catch((error) => {
+        teardownTaskListeners()
+        // Format message for listr output
+        const formattedMessage = formatLogMessageOneLine({
+          ts: (new Date()).toJSON(),
+          level: 'error',
+          error
+        })
+        const enrichedError = new Error(formattedMessage)
+
+        // Attach original error object for error log
+        enrichedError.originalError = error
+        throw enrichedError
+      })
+  }
+}

--- a/lib/utils/listr.js
+++ b/lib/utils/listr.js
@@ -1,6 +1,6 @@
 import { logToTaskOutput, formatLogMessageOneLine } from '../utils/logging'
 
-// Set up log listening form SDK and proper catching and throwing of SDK errors
+// Set up log emitter listening from SDK, proper error catching and throwing of SDK errors
 export function wrapTask (func) {
   return (ctx, task) => {
     const teardownTaskListeners = logToTaskOutput(task)
@@ -10,7 +10,7 @@ export function wrapTask (func) {
       })
       .catch((error) => {
         teardownTaskListeners()
-        // Format message for listr output
+        // Format message as human readable listr output
         const formattedMessage = formatLogMessageOneLine({
           ts: (new Date()).toJSON(),
           level: 'error',

--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -10,8 +10,9 @@ import getEntityName from './get-entity-name'
 export const logEmitter = new EventEmitter()
 
 function extractErrorInformation (error) {
+  let source = error.originalError || error
   try {
-    const data = JSON.parse(error.message)
+    const data = JSON.parse(source.message)
     if (isObject(data)) {
       return data
     }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-preset-env": "1.6.0",
     "babel-template": "^6.25.0",
     "babel-types": "^6.25.0",
+    "blue-tape": "^1.0.0",
     "coveralls": "2.13.1",
     "cz-conventional-changelog": "^2.0.0",
     "eslint": "^4.2.0",

--- a/test/utils/listr-test.js
+++ b/test/utils/listr-test.js
@@ -1,0 +1,71 @@
+import test from 'blue-tape'
+import sinon from 'sinon'
+
+import {
+  wrapTask,
+  __RewireAPI__ as listrRewireAPI
+} from '../../lib/utils/listr'
+
+const teardownListenerMock = sinon.stub()
+const listenerMock = sinon.stub().returns(teardownListenerMock)
+const formatMessageMock = sinon.stub().returns('formatted error message')
+
+function setup () {
+  listenerMock.resetHistory()
+  teardownListenerMock.resetHistory()
+  formatMessageMock.resetHistory()
+  listrRewireAPI.__Rewire__('logToTaskOutput', listenerMock)
+  listrRewireAPI.__Rewire__('formatLogMessageOneLine', formatMessageMock)
+}
+
+function teardown () {
+  listrRewireAPI.__ResetDependency__('logToTaskOutput')
+  listrRewireAPI.__ResetDependency__('formatLogMessageOneLine')
+}
+
+test('wraps task, sets up listeners and allows modification of task context', (t) => {
+  setup()
+
+  const ctx = {}
+
+  const wrappedTask = wrapTask((taskCtx) => {
+    taskCtx.done = true
+    return Promise.resolve()
+  })
+
+  return wrappedTask(ctx)
+    .then(() => {
+      t.equals(ctx.done, true, 'context got modified by the task')
+      t.equals(listenerMock.callCount, 1, 'task listener was initialized')
+      t.equals(teardownListenerMock.callCount, 1, 'task listener was teared down')
+      t.equals(formatMessageMock.callCount, 0, 'formatMessageMock was not called')
+      teardown()
+    })
+})
+
+test('wraps task and properly formats and throws error', (t) => {
+  setup()
+
+  const ctx = {}
+
+  const wrappedTask = wrapTask((taskCtx) => {
+    return Promise.reject(new Error('Task failed'))
+  })
+
+  return t.shouldFail(
+    wrappedTask(ctx)
+      .catch((err) => {
+        t.equals(Object.keys(ctx).length, 0, 'context got not modified by the task since it failed')
+        t.equals(err.message, 'formatted error message', 'error message contains formatted error message')
+        t.equals(err.originalError.message, 'Task failed', 'original error message is still present')
+        t.equals(listenerMock.callCount, 1, 'task listener was initialized')
+        t.equals(teardownListenerMock.callCount, 1, 'task listener was teared down')
+        t.equals(formatMessageMock.callCount, 1, 'formatMessageMock was called')
+        t.gt(formatMessageMock.args[0][0].ts.length, 0, 'log message contains a timestamp')
+        t.equals(formatMessageMock.args[0][0].level, 'error', 'log message has level of error')
+        t.equals(formatMessageMock.args[0][0].error.message, 'Task failed', 'log message error has original error message')
+        teardown()
+        throw err
+      })
+  )
+})


### PR DESCRIPTION
I guess this is the least effort to fix the display issue when a task itself fails and returns an error from the SDK.

Workarounding here the JSON.stringified error message here till we have a SDK error format which is easy to detect and work with.