### PR TITLE
test(jest): use jest 21 for node 4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,14 @@
 module.exports = {
-  extends: [
-    'standard',
-    'plugin:jest/recommended'
+  "extends": [
+      "standard",
+      "plugin:jest/recommended"
   ],
-  plugins: [
-    'standard',
-    'promise'
-  ]
-}
+  "plugins": [
+      "standard",
+      "promise"
+  ],
+  "rules": {
+      "jest/prefer-to-be-null": "warn",
+      "jest/prefer-to-be-undefined": "warn"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "husky": "0.14.3",
     "in-publish": "^2.0.0",
-    "jest": "^22.0.4",
+    "jest": "^21.2.1",
     "mkdirp": "^0.5.1",
     "opener": "^1.4.1",
     "rimraf": "^2.4.3",

--- a/test/push/creation.test.js
+++ b/test/push/creation.test.js
@@ -59,7 +59,7 @@ test('Create entities handle regular errors', () => {
       expect(logEmitter.emit.mock.calls[0][0]).toBe('error')
       expect(logEmitter.emit.mock.calls[0][1]).toBe(creationError)
       expect(result).toHaveLength(1)
-      expect(result[0]).toBe(null)
+      expect(result[0]).toBeNull()
     })
 })
 
@@ -149,7 +149,7 @@ test('Create entries and handle regular errors', () => {
       expect(logEmitter.emit.mock.calls[0][0]).toBe('error')
       expect(logEmitter.emit.mock.calls[0][1]).toBe(creationError)
       expect(result).toHaveLength(1)
-      expect(result[0]).toBe(null)
+      expect(result[0]).toBeNull()
     })
 })
 

--- a/test/push/publishing.test.js
+++ b/test/push/publishing.test.js
@@ -163,8 +163,8 @@ test('Skips archiving when no entities are given', () => {
   ])
     .then((result) => {
       expect(result).toHaveLength(2)
-      expect(result[0]).toMatchObject({archived: true}, 'First entry gets archived')
-      expect(result[1]).toBe(null, 'Second entry fails and will be returned as null')
+      expect(result[0]).toMatchObject({archived: true})
+      expect(result[1]).toBeNull()
       const warningCount = logEmitter.emit.mock.calls.filter((args) => args[0] === 'warning').length
       const errorCount = logEmitter.emit.mock.calls.filter((args) => args[0] === 'error').length
       expect(warningCount).toBe(0)


### PR DESCRIPTION
downgrade to jest 21 to make it work on node 4 till we can switch to node 6

I have no idea why this worked for node 4 for the last PR. 🤷‍♂️ 