### PR TITLE
test(transformer): remove duplicate protocol

### DIFF
--- a/lib/transform/transformers.js
+++ b/lib/transform/transformers.js
@@ -32,7 +32,8 @@ export function assets (asset) {
     (newFile, localizedFile, locale) => {
       newFile[locale] = pick(localizedFile, 'contentType', 'fileName')
       if (!localizedFile.uploadFrom) {
-        newFile[locale].upload = `https:${localizedFile.url || localizedFile.upload}`
+        const assetUrl = localizedFile.url || localizedFile.upload
+        newFile[locale].upload = `${/^(http|https):\/\/i/.test(assetUrl) ? '' : 'https:'}${assetUrl}`
       } else {
         newFile[locale].uploadFrom = localizedFile.uploadFrom
       }

--- a/test/transform/transformers.test.js
+++ b/test/transform/transformers.test.js
@@ -16,6 +16,21 @@ test('It should transform processed asset', () => {
   expect(transformedAsset.fields.file['de-DE'].upload).toBe('https:' + assetMock.fields.file['de-DE'].url)
 })
 
+test('It should transform processed asset with and without protocol', () => {
+  const assetMock = cloneMock('asset')
+  assetMock.fields = {
+    file: {
+      'en-US': {fileName: 'filename.jpg', url: 'https://server/filename.jpg'},
+      'de-DE': {fileName: 'filename.jpg', url: '//server/filename-de.jpg'}
+    }
+  }
+  const transformedAsset = transformers.assets(assetMock)
+  expect(transformedAsset.fields.file['en-US'].upload).toBeTruthy()
+  expect(transformedAsset.fields.file['de-DE'].upload).toBeTruthy()
+  expect(transformedAsset.fields.file['en-US'].upload).toBe('https:' + assetMock.fields.file['en-US'].url)
+  expect(transformedAsset.fields.file['de-DE'].upload).toBe('https:' + assetMock.fields.file['de-DE'].url)
+})
+
 test('It should transform unprocessed asset', () => {
   const assetMock = cloneMock('asset')
   assetMock.fields = {


### PR DESCRIPTION
This PR fixes the asset transformer to make sure the protocol of the asset url is set correctly without double `https:`