### PR TITLE
feature(proxy): add protocol to https-agent [SDK-2056]

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -62,7 +62,7 @@ export function agentFromProxy (proxy) {
     delete process.env[envStr]
     delete process.env[envStr.toUpperCase()]
   })
-  const { host, port } = proxy
-  const agent = new HttpsProxyAgent({ host, port })
+  const { host, port, protocol } = proxy
+  const agent = new HttpsProxyAgent({ host, port, protocol })
   return agent
 }

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -127,7 +127,8 @@ test('agentFromProxy creates https agent and removes proxy env variables', () =>
   process.env.https_proxy = true
   const agentParams = {
     host: 'foo.bar',
-    port: 1234
+    port: 1234,
+    protocol: 'http'
   }
   const agent = agentFromProxy(agentParams)
   expect(process.env).not.toHaveProperty('HTTP_PROXY')


### PR DESCRIPTION
Added protocol property to be passed to the https-proxy-agent since this is in line with [what the agent expects](https://github.com/TooTallNate/node-https-proxy-agent/blob/c30a9dc75a272591a80b9b4acef1496f80824f88/src/agent.ts#L50) for TLS upgrade. 