### PR TITLE
feat(index.js): add single entrypoint

### DIFF
--- a/lib/add-sequence-header.js
+++ b/lib/add-sequence-header.js
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
  * Adds a sequence header to a header object
  * @param {object} headers
  */
+// TODO: next major release (v9.0.0+) - change this to a non-default export.
 export default function addSequenceHeader (headers) {
   if (typeof headers !== 'object') throw new Error('addSequence function expects an object as input')
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+export { default as addSequenceHeader } from './add-sequence-header'
+export { default as getEntityName } from './get-entity-name'
+export { wrapTask } from './listr'
+export { logEmitter, displayErrorLog, setupLogging, writeErrorLogFile } from './logging'
+export { proxyStringToObject, agentFromProxy } from './proxy'

--- a/test/add-sequence-header.test.js
+++ b/test/add-sequence-header.test.js
@@ -1,4 +1,4 @@
-import addSequenceHeader from '../lib/add-sequence-header'
+import { addSequenceHeader } from '../lib'
 
 test('adds sequence header to empty object', () => {
   const headers = addSequenceHeader({})

--- a/test/get-entity-name.test.js
+++ b/test/get-entity-name.test.js
@@ -1,4 +1,4 @@
-import getEntityName from '../lib/get-entity-name'
+import { getEntityName } from '../lib'
 
 test('get name by name property', () => {
   const name = getEntityName({

--- a/test/listr.test.js
+++ b/test/listr.test.js
@@ -1,12 +1,5 @@
-import {
-  wrapTask
-} from '../lib/listr'
-
-import {
-  logToTaskOutput,
-  teardownHelperMock,
-  formatLogMessageOneLine
-} from '../lib/logging'
+import { wrapTask } from '../lib'
+import { logToTaskOutput, teardownHelperMock, formatLogMessageOneLine } from '../lib/logging'
 
 jest.mock('../lib/logging', () => {
   const teardownHelperMock = jest.fn()


### PR DESCRIPTION
Currently consumers of this package are required to know the internal structure to import required modules. This PR introduces an `index.js` file to alleviate this problem.

Previous import syntax:
```js
import { wrapTask } from 'contentful-batch-libs/dist/listr';
import { logEmitter } from 'contentful-batch-libs/dist/logging';
```

New syntax:
```js
import { wrapTask, logEmitter } from 'contentful-batch-libs';
```

This PR introduces no breaking changes in itself. However, I have left some todo's to suggest next major release to remove `export default` in favour of named exports.

Additionally I do not believe every function in this package needs to be exported from this new `index.js` file. I have only included exports that are used in either the `contentful-export` or `contentful-import` tools.