### PR TITLE
chore(deps): replace moment with date-fns

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events'
 
 import bfj from 'bfj'
 import figures from 'figures'
-import moment from 'moment'
+import format from 'date-fns/format'
 
 import getEntityName from './get-entity-name'
 
@@ -98,7 +98,7 @@ export function displayErrorLog (errorLog) {
     console.log(`\n\nThe following ${errorsCount} errors and ${warningsCount} warnings occurred:\n`)
 
     errorLog
-      .map((logMessage) => `${moment(logMessage.ts).format('HH:mm:SS')} - ${formatLogMessageOneLine(logMessage)}`)
+      .map((logMessage) => `${format(logMessage.ts, 'HH:mm:ss')} - ${formatLogMessageOneLine(logMessage)}`)
       .map((logMessage) => console.log(logMessage))
 
     return

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "bfj": "^7.0.2",
+        "date-fns": "^2.28.0",
         "figures": "^3.2.0",
         "https-proxy-agent": "^3.0.0",
         "lodash.clonedeep": "^4.5.0",
-        "moment": "^2.29.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -7608,6 +7608,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -13453,14 +13465,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -25071,6 +25075,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -29436,11 +29445,6 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "bfj": "^7.0.2",
+    "date-fns": "^2.28.0",
     "figures": "^3.2.0",
     "https-proxy-agent": "^3.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "moment": "^2.29.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -26,12 +26,12 @@ const logEmitterEmitSpy = jest.spyOn(logEmitter, 'emit')
 
 const exampleErrorLog = [
   {
-    ts: new Date('2018-01-01T01:01:01+01:00'),
+    ts: new Date('2018-01-01T01:01:43+01:00'),
     level: 'warning',
     warning: 'warning text'
   },
   {
-    ts: new Date('2018-02-02T02:02:02+01:00'),
+    ts: new Date('2018-02-02T02:02:22+01:00'),
     level: 'error',
     error: new Error('error message')
   }


### PR DESCRIPTION
Now that moment.js is not being used in either contentful-import or contentful-export, it is safe to replace this now with date-fns. See https://github.com/contentful/contentful-import/pull/602 for more info