### PR TITLE
fix(date-fns): fix invalid time error

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -3,6 +3,7 @@ import EventEmitter from 'events'
 import bfj from 'bfj'
 import figures from 'figures'
 import format from 'date-fns/format'
+import parseISO from 'date-fns/parseISO'
 
 import getEntityName from './get-entity-name'
 
@@ -98,7 +99,7 @@ export function displayErrorLog (errorLog) {
     console.log(`\n\nThe following ${errorsCount} errors and ${warningsCount} warnings occurred:\n`)
 
     errorLog
-      .map((logMessage) => `${format(logMessage.ts, 'HH:mm:ss')} - ${formatLogMessageOneLine(logMessage)}`)
+      .map((logMessage) => `${format(parseISO(logMessage.ts), 'HH:mm:ss')} - ${formatLogMessageOneLine(logMessage)}`)
       .map((logMessage) => console.log(logMessage))
 
     return

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -26,12 +26,12 @@ const logEmitterEmitSpy = jest.spyOn(logEmitter, 'emit')
 
 const exampleErrorLog = [
   {
-    ts: new Date('2018-01-01T01:01:43+01:00'),
+    ts: new Date('2018-01-01T01:01:43+01:00').toJSON(),
     level: 'warning',
     warning: 'warning text'
   },
   {
-    ts: new Date('2018-02-02T02:02:22+01:00'),
+    ts: new Date('2018-02-02T02:02:22+01:00').toJSON(),
     level: 'error',
     error: new Error('error message')
   }


### PR DESCRIPTION
While replacing moment.js with date-fns, it was assumed the tests were correct. Unfortunately this is not the case: 
- unit tests assumed timestamps were of type `number`
- users are converting timestamps to a string, commonly `new Date().toJson()`

This will address the following downstream reported issue: https://github.com/contentful/contentful-cli/issues/1507