### PR TITLE
chore(tests): tidy tests to be @types/jest compliant

### DIFF
--- a/test/listr.test.js
+++ b/test/listr.test.js
@@ -4,7 +4,7 @@ import { logToTaskOutput, formatLogMessageOneLine } from '../lib/logging'
 jest.mock('../lib/logging', () => {
   return {
     formatLogMessageOneLine: jest.fn((logMessage) => `formatted: ${logMessage.error.message}`),
-    logToTaskOutput: jest.fn(() => null)
+    logToTaskOutput: jest.fn(() => jest.fn())
   }
 })
 

--- a/test/listr.test.js
+++ b/test/listr.test.js
@@ -1,11 +1,13 @@
 import { wrapTask } from '../lib'
-import { logToTaskOutput, formatLogMessageOneLine } from '../lib/logging'
+import * as logging from '../lib/logging'
 
-jest.mock('../lib/logging', () => {
-  return {
-    formatLogMessageOneLine: jest.fn((logMessage) => `formatted: ${logMessage.error.message}`),
-    logToTaskOutput: jest.fn(() => jest.fn())
-  }
+jest.mock('../lib/logging')
+
+const { logToTaskOutput, formatLogMessageOneLine } = logging
+
+beforeEach(() => {
+  formatLogMessageOneLine.mockImplementation((logMessage) => `formatted: ${logMessage.error.message}`)
+  logToTaskOutput.mockImplementation(() => jest.fn())
 })
 
 afterEach(() => {
@@ -36,12 +38,16 @@ test('wraps task and properly formats and throws error', async () => {
 
   const wrappedTask = wrapTask(() => Promise.reject(new Error(errorMessage)))
 
-  await expect(wrappedTask(ctx)).rejects.toThrow({
-    message: `formatted: ${errorMessage}`,
-    originalError: {
-      message: errorMessage
-    }
-  })
+  try {
+    await wrappedTask(ctx)
+  } catch (err) {
+    expect(err).toMatchObject({
+      message: `formatted: ${errorMessage}`,
+      originalError: {
+        message: errorMessage
+      }
+    })
+  }
 
   expect(Object.keys(ctx)).toHaveLength(0)
   expect(logToTaskOutput.mock.calls).toHaveLength(1)

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -147,24 +147,23 @@ test('does not displays error log when empty', () => {
   expect(consoleLogSpy.mock.calls[0][0]).toContain('No errors or warnings occurred')
 })
 
-test('writes error log file to disk', () => {
-  expect.assertions(7)
+test('writes error log file to disk', async () => {
+  expect.assertions(8)
   const destination = '/just/some/path/to/a/file.log'
 
-  return writeErrorLogFile(destination, exampleErrorLog)
-    .then(() => {
-      expect(consoleLogSpy.mock.calls).toHaveLength(2)
-      expect(consoleLogSpy.mock.calls[0][0]).toBe('\nStored the detailed error log file at:')
-      expect(consoleLogSpy.mock.calls[1][0]).toBe(destination)
+  await expect(writeErrorLogFile(destination, exampleErrorLog)).resolves.not.toThrow()
 
-      expect(bfj.write.mock.calls).toHaveLength(1)
-      expect(bfj.write.mock.calls[0][0]).toBe(destination)
-      expect(bfj.write.mock.calls[0][1]).toMatchObject(exampleErrorLog)
-      expect(bfj.write.mock.calls[0][2]).toMatchObject({
-        circular: 'ignore',
-        space: 2
-      })
-    })
+  expect(consoleLogSpy.mock.calls).toHaveLength(2)
+  expect(consoleLogSpy.mock.calls[0][0]).toBe('\nStored the detailed error log file at:')
+  expect(consoleLogSpy.mock.calls[1][0]).toBe(destination)
+
+  expect(bfj.write.mock.calls).toHaveLength(1)
+  expect(bfj.write.mock.calls[0][0]).toBe(destination)
+  expect(bfj.write.mock.calls[0][1]).toMatchObject(exampleErrorLog)
+  expect(bfj.write.mock.calls[0][2]).toMatchObject({
+    circular: 'ignore',
+    space: 2
+  })
 })
 
 test('sets up logging via event emitter', () => {
@@ -196,21 +195,21 @@ test('sets up logging via event emitter', () => {
   logEmitterEmitSpy.mockClear()
   logEmitter.emit('info', 'example info')
   expect(logEmitterEmitSpy.mock.calls[1][0]).toBe('display')
-  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true, 'attaches valid timestamp to log message')
+  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true)
   expect(logEmitterEmitSpy.mock.calls[1][1].level).toBe('info')
   expect(logEmitterEmitSpy.mock.calls[1][1].info).toBe('example info')
 
   logEmitterEmitSpy.mockClear()
   logEmitter.emit('warning', 'example warning')
   expect(logEmitterEmitSpy.mock.calls[1][0]).toBe('display')
-  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true, 'attaches valid timestamp to log message')
+  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true)
   expect(logEmitterEmitSpy.mock.calls[1][1].level).toBe('warning')
   expect(logEmitterEmitSpy.mock.calls[1][1].warning).toBe('example warning')
 
   logEmitterEmitSpy.mockClear()
   logEmitter.emit('error', 'example error')
   expect(logEmitterEmitSpy.mock.calls[1][0]).toBe('display')
-  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true, 'attaches valid timestamp to log message')
+  expect(isValidDate(logEmitterEmitSpy.mock.calls[1][1].ts)).toBe(true)
   expect(logEmitterEmitSpy.mock.calls[1][1].level).toBe('error')
   expect(logEmitterEmitSpy.mock.calls[1][1].error).toBe('example error')
 

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,18 +1,11 @@
+import HttpsProxyAgent from 'https-proxy-agent'
 import {
   proxyStringToObject,
   proxyObjectToString,
   agentFromProxy
 } from '../lib/proxy'
 
-jest.mock('https-proxy-agent', () => {
-  const mock = jest.fn()
-  return class mocked {
-    constructor (args) {
-      this.mock = mock
-      mock(args)
-    }
-  }
-})
+jest.mock('https-proxy-agent')
 
 test('proxyString with basic auth, with protocol', () => {
   const proxyString = 'http://foo:bar@127.0.0.1:8213'
@@ -130,10 +123,14 @@ test('agentFromProxy creates https agent and removes proxy env variables', () =>
     port: 1234,
     protocol: 'http'
   }
+
   const agent = agentFromProxy(agentParams)
+
+  expect(agent).toBeInstanceOf(HttpsProxyAgent)
+  expect(HttpsProxyAgent.mock.calls[0][0]).toMatchObject(agentParams)
+
   expect(process.env).not.toHaveProperty('HTTP_PROXY')
   expect(process.env).not.toHaveProperty('http_proxy')
   expect(process.env).not.toHaveProperty('HTTPS_PROXY')
   expect(process.env).not.toHaveProperty('https_proxy')
-  expect(agent.mock.mock.calls[0][0]).toMatchObject(agentParams)
 })


### PR DESCRIPTION
- Refactor tests to use async/await syntax
- Remove custom test expect messages - the jest API does not support this (found this whilst trying to refactor to TS)
- General code clean up