### PR TITLE
fix(logging): fix reported errors count

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -94,9 +94,13 @@ export function formatLogMessageLogfile (logMessage) {
 // Display all errors
 export function displayErrorLog (errorLog) {
   if (errorLog.length) {
-    const warningsCount = errorLog.filter((error) => Object.prototype.hasOwnProperty.call(error, 'warning')).length
-    const errorsCount = errorLog.filter((error) => Object.prototype.hasOwnProperty.call(error, 'warning')).length
-    console.log(`\n\nThe following ${errorsCount} errors and ${warningsCount} warnings occurred:\n`)
+    const count = errorLog.reduce((count, curr) => {
+      if (Object.prototype.hasOwnProperty.call(curr, 'warning')) count.warnings++
+      else if (Object.prototype.hasOwnProperty.call(curr, 'error')) count.errors++
+      return count
+    }, { warnings: 0, errors: 0 })
+
+    console.log(`\n\nThe following ${count.errors} errors and ${count.warnings} warnings occurred:\n`)
 
     errorLog
       .map((logMessage) => `${format(parseISO(logMessage.ts), 'HH:mm:ss')} - ${formatLogMessageOneLine(logMessage)}`)

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -132,12 +132,19 @@ test('format log file log message with level info', () => {
 })
 
 test('displays error log well formatted', () => {
-  displayErrorLog(exampleErrorLog)
+  const extendedExampleErrorLog = [...exampleErrorLog, {
+    ts: new Date('2022-01-01T01:05:43+01:00').toJSON(),
+    level: 'warning',
+    warning: 'another warning'
+  }]
 
-  expect(consoleLogSpy.mock.calls).toHaveLength(3)
-  expect(consoleLogSpy.mock.calls[0][0]).toContain('The following 1 errors and 1 warnings occurred:')
+  displayErrorLog(extendedExampleErrorLog)
+
+  expect(consoleLogSpy.mock.calls).toHaveLength(4)
+  expect(consoleLogSpy.mock.calls[0][0]).toContain('The following 1 errors and 2 warnings occurred:')
   expect(consoleLogSpy.mock.calls[1][0]).toMatch(/\d{2}:\d{2}:\d{2} - warning text/)
   expect(consoleLogSpy.mock.calls[2][0]).toMatch(/\d{2}:\d{2}:\d{2} - Error: error message/)
+  expect(consoleLogSpy.mock.calls[3][0]).toMatch(/\d{2}:\d{2}:\d{2} - another warning/)
 })
 
 test('does not displays error log when empty', () => {


### PR DESCRIPTION
Found this issue when migration the file to TS, thought it would be worthwhile to separate it into its own PR. The problem is this line:
```js
const errorsCount = errorLog.filter((error) => Object.prototype.hasOwnProperty.call(error, 'warning')).length
```

As you can see it is counting the number of warnings (not errors).

In fixing this PR, I modified this code to use the `Array.prototype.reduce` function to prevent iterating over the `errorLog` array twice.