### PR TITLE
fix: https-proxy-agent usage after version bump [NONE]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       time: "00:00"
       timezone: UTC
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: bfj # ignore ESM only versions
+        versions:
+          - ">=8.0.0"
+      - dependency-name: figures  # ignore ESM only versions
+        versions:
+          - ">=4.0.0"
     commit-message:
       prefix: build
       include: scope

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,5 +1,5 @@
-import { URL, format } from 'url'
-import HttpsProxyAgent from 'https-proxy-agent'
+import { format, URL } from 'url'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 
 function serializeAuth ({ username, password } = {}) {
   if (!username) {
@@ -62,7 +62,6 @@ export function agentFromProxy (proxy) {
     delete process.env[envStr]
     delete process.env[envStr.toUpperCase()]
   })
-  const { host, port, protocol } = proxy
-  const agent = new HttpsProxyAgent({ host, port, protocol })
-  return agent
+
+  return new HttpsProxyAgent(proxyObjectToString(proxy))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "bfj": "^8.0.0",
+        "bfj": "7.1.0",
         "date-fns": "^2.28.0",
-        "figures": "^5.0.0",
+        "figures": "3.2.0",
         "https-proxy-agent": "^7.0.2",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.1"
@@ -6879,9 +6879,9 @@
       "dev": true
     },
     "node_modules/bfj": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-8.0.0.tgz",
-      "integrity": "sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
+      "integrity": "sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "check-types": "^11.2.3",
@@ -6890,7 +6890,7 @@
         "tryer": "^1.0.1"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -8447,7 +8447,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -9650,26 +9649,14 @@
       }
     },
     "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
+        "escape-string-regexp": "^1.0.5"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11009,6 +10996,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -20181,6 +20169,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semantic-release/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semantic-release/node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -27153,9 +27157,9 @@
       "dev": true
     },
     "bfj": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-8.0.0.tgz",
-      "integrity": "sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
+      "integrity": "sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==",
       "requires": {
         "bluebird": "^3.7.2",
         "check-types": "^11.2.3",
@@ -28333,8 +28337,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
       "version": "8.51.0",
@@ -29177,19 +29180,11 @@
       }
     },
     "figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "requires": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        }
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -30154,7 +30149,8 @@
     "is-unicode-supported": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -36731,6 +36727,16 @@
               "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
               "dev": true
             }
+          }
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
           }
         },
         "human-signals": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "prepush": "npm run test"
   },
   "dependencies": {
-    "bfj": "^8.0.0",
+    "bfj": "7.1.0",
     "date-fns": "^2.28.0",
-    "figures": "^5.0.0",
+    "figures": "3.2.0",
     "https-proxy-agent": "^7.0.2",
     "lodash.clonedeep": "^4.5.0",
     "uuid": "^9.0.1"

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,9 +1,10 @@
-import HttpsProxyAgent from 'https-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import {
   proxyStringToObject,
   proxyObjectToString,
   agentFromProxy
 } from '../lib/proxy'
+import expect from 'expect'
 
 jest.mock('https-proxy-agent')
 
@@ -127,7 +128,7 @@ test('agentFromProxy creates https agent and removes proxy env variables', () =>
   const agent = agentFromProxy(agentParams)
 
   expect(agent).toBeInstanceOf(HttpsProxyAgent)
-  expect(HttpsProxyAgent.mock.calls[0][0]).toMatchObject(agentParams)
+  expect(HttpsProxyAgent.mock.calls[0][0]).toBe(proxyObjectToString(agentParams))
 
   expect(process.env).not.toHaveProperty('HTTP_PROXY')
   expect(process.env).not.toHaveProperty('http_proxy')


### PR DESCRIPTION
After [bumping](https://github.com/contentful/contentful-batch-libs/pull/199) `https-proxy-agent`, the usage broke due to a [changed](https://github.com/TooTallNate/proxy-agents/blob/main/packages/https-proxy-agent/CHANGELOG.md#600) interface. This change aligns with the new format. To ensure such insecure changes do not end up on `master` again, the branch protection rule has been restricted with the required checks.

Additionally we pinned dependencies with ESM only bundles.