### PR TITLE
feat: Remove BFJ for async streaming

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
       timezone: UTC
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: bfj # ignore ESM only versions
-        versions:
-          - ">=8.0.0"
       - dependency-name: figures  # ignore ESM only versions
         versions:
           - ">=4.0.0"

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -100,7 +100,11 @@ export function displayErrorLog (errorLog) {
   if (errorLog.length) {
     const count = errorLog.reduce(
       (count, curr) => {
-        if (Object.prototype.hasOwnProperty.call(curr, 'warning')) { count.warnings++ } else if (Object.prototype.hasOwnProperty.call(curr, 'error')) { count.errors++ }
+        if (Object.prototype.hasOwnProperty.call(curr, 'warning')) {
+          count.warnings++
+        } else if (Object.prototype.hasOwnProperty.call(curr, 'error')) {
+          count.errors++
+        }
         return count
       },
       { warnings: 0, errors: 0 }
@@ -127,7 +131,7 @@ export function displayErrorLog (errorLog) {
 
 /**
  * Write all log messages instead of infos to the error log file
- * @param {import ('node:fs').PathLike} destination
+ * @param {import('node:fs').PathLike} destination
  * @param {Record<string, unknown>[]} errorLog
  * @returns {Promise<void>}
  */

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,15 +1,15 @@
-import EventEmitter from 'events'
-
-import bfj from 'bfj'
-import figures from 'figures'
 import format from 'date-fns/format'
 import parseISO from 'date-fns/parseISO'
-
+import figures from 'figures'
+import EventEmitter from 'node:events'
+import { createWriteStream } from 'node:fs'
+import { Readable, Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import getEntityName from './get-entity-name'
 
 export const logEmitter = new EventEmitter()
 
-function extractErrorInformation (error) {
+function extractErrorInformation(error) {
   const source = error.originalError || error
   try {
     const data = JSON.parse(source.message)
@@ -21,7 +21,7 @@ function extractErrorInformation (error) {
   }
 }
 
-export function formatLogMessageOneLine (logMessage) {
+export function formatLogMessageOneLine(logMessage) {
   const { level } = logMessage
   if (!level) {
     return logMessage.toString().replace(/\s+/g, ' ')
@@ -47,7 +47,9 @@ export function formatLogMessageOneLine (logMessage) {
       errorOutput.push(`Entity: ${getEntityName(data.entity)}`)
     }
     if ('details' in data && 'errors' in data.details) {
-      const errorList = data.details.errors.map((error) => error.details || error.name)
+      const errorList = data.details.errors.map(
+        (error) => error.details || error.name
+      )
       errorOutput.push(`Details: ${errorList.join(', ')}`)
     }
     if ('requestId' in data) {
@@ -60,7 +62,7 @@ export function formatLogMessageOneLine (logMessage) {
   }
 }
 
-export function formatLogMessageLogfile (logMessage) {
+export function formatLogMessagelogFileWriteStream(logMessage) {
   const { level } = logMessage
   if (level === 'info' || level === 'warning') {
     return logMessage
@@ -78,7 +80,9 @@ export function formatLogMessageLogfile (logMessage) {
   } catch (err) {
     // Fallback for errors without API information
     if (logMessage.error.stack) {
-      logMessage.error.stacktrace = logMessage.error.stack.toString().split(/\n +at /)
+      logMessage.error.stacktrace = logMessage.error.stack
+        .toString()
+        .split(/\n +at /)
     }
   }
 
@@ -92,18 +96,31 @@ export function formatLogMessageLogfile (logMessage) {
 }
 
 // Display all errors
-export function displayErrorLog (errorLog) {
+export function displayErrorLog(errorLog) {
   if (errorLog.length) {
-    const count = errorLog.reduce((count, curr) => {
-      if (Object.prototype.hasOwnProperty.call(curr, 'warning')) count.warnings++
-      else if (Object.prototype.hasOwnProperty.call(curr, 'error')) count.errors++
-      return count
-    }, { warnings: 0, errors: 0 })
+    const count = errorLog.reduce(
+      (count, curr) => {
+        if (Object.prototype.hasOwnProperty.call(curr, 'warning'))
+          count.warnings++
+        else if (Object.prototype.hasOwnProperty.call(curr, 'error'))
+          count.errors++
+        return count
+      },
+      { warnings: 0, errors: 0 }
+    )
 
-    console.log(`\n\nThe following ${count.errors} errors and ${count.warnings} warnings occurred:\n`)
+    console.log(
+      `\n\nThe following ${count.errors} errors and ${count.warnings} warnings occurred:\n`
+    )
 
     errorLog
-      .map((logMessage) => `${format(parseISO(logMessage.ts), 'HH:mm:ss')} - ${formatLogMessageOneLine(logMessage)}`)
+      .map(
+        (logMessage) =>
+          `${format(
+            parseISO(logMessage.ts),
+            'HH:mm:ss'
+          )} - ${formatLogMessageOneLine(logMessage)}`
+      )
       .map((logMessage) => console.log(logMessage))
 
     return
@@ -111,30 +128,47 @@ export function displayErrorLog (errorLog) {
   console.log('No errors or warnings occurred')
 }
 
-// Write all log messages instead of infos to the error log file
-export function writeErrorLogFile (destination, errorLog) {
-  const logFileData = errorLog
-    .map(formatLogMessageLogfile)
-
-  return bfj.write(destination, logFileData, {
-    circular: 'ignore',
-    space: 2
+/**
+ * Write all log messages instead of infos to the error log file
+ * @param {import ('node:fs').PathLike} destination
+ * @param {Record<string, unknown>[]} errorLog
+ * @returns {Promise<void>}
+ */
+export async function writeErrorLogFile(destination, errorLog) {
+  const formatLogTransformer = new Transform({
+    objectMode: true,
+    transform: (chunk, encoding, callback) => {
+      const formattedChunk = formatLogMessagelogFileWriteStream(chunk)
+      callback(null, Buffer.from(JSON.stringify(formattedChunk)))
+    }
   })
-    .then(() => {
-      console.log('\nStored the detailed error log file at:')
-      console.log(destination)
-    })
-    .catch((e) => {
-      // avoid crashing when writing the log file fails
-      console.error(e)
-    })
+
+  const logFileWriteStream = createWriteStream(destination)
+
+  try {
+    await pipeline([
+      Readable.from(errorLog),
+      formatLogTransformer,
+      logFileWriteStream
+    ])
+
+    console.log('\nStored the detailed error log file at:')
+    console.log(destination)
+  } catch (err) {
+    // avoid crashing when writing the log file fails
+    console.error(err)
+  }
 }
 
-// Init listeners for log messages, transform them into proper format and logs/displays them
-export function setupLogging (log) {
-  function errorLogger (level, error) {
+/**
+ * Init listeners for log messages, transform them into proper format and logs/displays them
+ * @param {Record<string,unknown>[]} log
+ * @returns {Promise<void>}
+ */
+export function setupLogging(log) {
+  function errorLogger(level, error) {
     const logMessage = {
-      ts: (new Date()).toJSON(),
+      ts: new Date().toJSON(),
       level,
       [level]: error
     }
@@ -149,9 +183,13 @@ export function setupLogging (log) {
   logEmitter.addListener('error', (error) => errorLogger('error', error))
 }
 
-// Format log message to display them as task status
-export function logToTaskOutput (task) {
-  function logToTask (logMessage) {
+/**
+ * Format log message to display them as task status
+ * @template {Ctx}
+ * @param {import('listr').ListrTaskWrapper<Ctx>} task
+ */
+export function logToTaskOutput(task) {
+  function logToTask(logMessage) {
     const content = formatLogMessageOneLine(logMessage)
     const symbols = {
       info: figures.tick,

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -62,7 +62,7 @@ export function formatLogMessageOneLine (logMessage) {
   }
 }
 
-export function formatLogMessagelogFileWriteStream (logMessage) {
+export function formatLogMessageLogfile (logMessage) {
   const { level } = logMessage
   if (level === 'info' || level === 'warning') {
     return logMessage
@@ -135,7 +135,7 @@ export async function writeErrorLogFile (destination, errorLog) {
   const formatLogTransformer = new Transform({
     objectMode: true,
     transform: (chunk, encoding, callback) => {
-      const formattedChunk = formatLogMessagelogFileWriteStream(chunk)
+      const formattedChunk = formatLogMessageLogfile(chunk)
       callback(null, Buffer.from(JSON.stringify(formattedChunk)))
     }
   })

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -9,7 +9,7 @@ import getEntityName from './get-entity-name'
 
 export const logEmitter = new EventEmitter()
 
-function extractErrorInformation(error) {
+function extractErrorInformation (error) {
   const source = error.originalError || error
   try {
     const data = JSON.parse(source.message)
@@ -21,7 +21,7 @@ function extractErrorInformation(error) {
   }
 }
 
-export function formatLogMessageOneLine(logMessage) {
+export function formatLogMessageOneLine (logMessage) {
   const { level } = logMessage
   if (!level) {
     return logMessage.toString().replace(/\s+/g, ' ')
@@ -62,7 +62,7 @@ export function formatLogMessageOneLine(logMessage) {
   }
 }
 
-export function formatLogMessagelogFileWriteStream(logMessage) {
+export function formatLogMessagelogFileWriteStream (logMessage) {
   const { level } = logMessage
   if (level === 'info' || level === 'warning') {
     return logMessage
@@ -96,14 +96,11 @@ export function formatLogMessagelogFileWriteStream(logMessage) {
 }
 
 // Display all errors
-export function displayErrorLog(errorLog) {
+export function displayErrorLog (errorLog) {
   if (errorLog.length) {
     const count = errorLog.reduce(
       (count, curr) => {
-        if (Object.prototype.hasOwnProperty.call(curr, 'warning'))
-          count.warnings++
-        else if (Object.prototype.hasOwnProperty.call(curr, 'error'))
-          count.errors++
+        if (Object.prototype.hasOwnProperty.call(curr, 'warning')) { count.warnings++ } else if (Object.prototype.hasOwnProperty.call(curr, 'error')) { count.errors++ }
         return count
       },
       { warnings: 0, errors: 0 }
@@ -134,7 +131,7 @@ export function displayErrorLog(errorLog) {
  * @param {Record<string, unknown>[]} errorLog
  * @returns {Promise<void>}
  */
-export async function writeErrorLogFile(destination, errorLog) {
+export async function writeErrorLogFile (destination, errorLog) {
   const formatLogTransformer = new Transform({
     objectMode: true,
     transform: (chunk, encoding, callback) => {
@@ -165,8 +162,8 @@ export async function writeErrorLogFile(destination, errorLog) {
  * @param {Record<string,unknown>[]} log
  * @returns {Promise<void>}
  */
-export function setupLogging(log) {
-  function errorLogger(level, error) {
+export function setupLogging (log) {
+  function errorLogger (level, error) {
     const logMessage = {
       ts: new Date().toJSON(),
       level,
@@ -188,8 +185,8 @@ export function setupLogging(log) {
  * @template {Ctx}
  * @param {import('listr').ListrTaskWrapper<Ctx>} task
  */
-export function logToTaskOutput(task) {
-  function logToTask(logMessage) {
+export function logToTaskOutput (task) {
+  function logToTask (logMessage) {
     const content = formatLogMessageOneLine(logMessage)
     const symbols = {
       info: figures.tick,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "contentful-batch-libs",
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "bfj": "7.1.0",
         "date-fns": "^2.28.0",
         "figures": "3.2.0",
         "https-proxy-agent": "^7.0.2",
@@ -6217,21 +6215,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/bfj": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
-      "integrity": "sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==",
-      "dependencies": {
-        "bluebird": "^3.7.2",
-        "check-types": "^11.2.3",
-        "hoopy": "^0.1.4",
-        "jsonpath": "^1.1.1",
-        "tryer": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6241,11 +6224,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -6451,11 +6429,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/check-types": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
-      "integrity": "sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg=="
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -7310,7 +7283,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -8632,6 +8606,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -8686,6 +8661,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -8694,6 +8670,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8815,7 +8792,8 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -9541,14 +9519,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hoopy": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -12220,28 +12190,6 @@
       "engines": [
         "node >= 0.2.0"
       ]
-    },
-    "node_modules/jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
-      "dependencies": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      }
-    },
-    "node_modules/jsonpath/node_modules/esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -18396,91 +18344,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dependencies": {
-        "escodegen": "^1.8.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-eval/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -18874,11 +18737,6 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
-    "node_modules/tryer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
-    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -19127,11 +18985,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
-    },
     "node_modules/undici-types": {
       "version": "5.25.3",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
@@ -19370,6 +19223,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24274,29 +24128,12 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "bfj": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
-      "integrity": "sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==",
-      "requires": {
-        "bluebird": "^3.7.2",
-        "check-types": "^11.2.3",
-        "hoopy": "^0.1.4",
-        "jsonpath": "^1.1.1",
-        "tryer": "^1.0.1"
-      }
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "optional": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bottleneck": {
       "version": "2.19.5",
@@ -24440,11 +24277,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "check-types": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
-      "integrity": "sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg=="
     },
     "chokidar": {
       "version": "3.5.2",
@@ -25107,7 +24939,8 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -26017,7 +25850,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.5.0",
@@ -26056,12 +25890,14 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "eventemitter3": {
       "version": "5.0.1",
@@ -26159,7 +25995,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -26698,11 +26535,6 @@
       "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
       "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true
-    },
-    "hoopy": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
       "version": "7.0.1",
@@ -28646,23 +28478,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
-    },
-    "jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A=="
-        }
-      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -32910,69 +32725,6 @@
         }
       }
     },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "requires": {
-        "escodegen": "^1.8.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.14.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        }
-      }
-    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -33266,11 +33018,6 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
-    "tryer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
-    },
     "ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -33445,11 +33192,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
-    },
     "undici-types": {
       "version": "5.25.3",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
@@ -33615,7 +33357,8 @@
     "word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "prepush": "npm run test"
   },
   "dependencies": {
-    "bfj": "7.1.0",
     "date-fns": "^2.28.0",
     "figures": "3.2.0",
     "https-proxy-agent": "^7.0.2",

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -172,7 +172,7 @@ test('does not displays error log when empty', () => {
   )
 })
 
-test.only('writes error log file to disk', async () => {
+test('writes error log file to disk', async () => {
   expect.assertions(6)
   const destination = '/just/some/path/to/a/file.log'
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,5 +1,4 @@
-import fs from 'node:fs'
-import { Writable } from 'node:stream'
+import fs, { WriteStream } from 'node:fs'
 import {
   formatLogMessageOneLine,
   formatLogMessageLogfile,
@@ -181,7 +180,7 @@ test('writes error log file to disk', async () => {
   const writeStreamSpy = jest
     .spyOn(fs, 'createWriteStream')
     .mockImplementation(() => {
-      return new Writable({
+      return new WriteStream({
         write: (chunk, b, cb) => {
           try {
             chunks.push(JSON.parse(chunk.toString('utf-8')))

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,4 +1,5 @@
-import fs, { WriteStream } from 'node:fs'
+import fs from 'node:fs'
+import { Writable } from 'node:stream'
 import {
   formatLogMessageOneLine,
   formatLogMessageLogfile,
@@ -180,7 +181,7 @@ test('writes error log file to disk', async () => {
   const writeStreamSpy = jest
     .spyOn(fs, 'createWriteStream')
     .mockImplementation(() => {
-      return new WriteStream({
+      return new Writable({
         write: (chunk, b, cb) => {
           try {
             chunks.push(JSON.parse(chunk.toString('utf-8')))

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -11,7 +11,7 @@ import {
 } from '../lib/logging'
 import figures from 'figures'
 
-function isValidDate(date) {
+function isValidDate (date) {
   return !isNaN(Date.parse(date))
 }
 
@@ -207,7 +207,7 @@ test('sets up logging via event emitter', () => {
   expect(logEmitterAddListenerSpy.mock.calls[1][0]).toBe('warning')
   expect(logEmitterAddListenerSpy.mock.calls[2][0]).toBe('error')
 
-  function assertLogValues(logMessage) {
+  function assertLogValues (logMessage) {
     if (logMessage.level === 'info') {
       //  Info messages are not logged
       return

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,6 +2,7 @@ import type { EventEmitter } from 'events'
 import type { ContentfulClientApi } from 'contentful'
 import type { ClientAPI, EntryProps } from 'contentful-management'
 import type HttpsProxyAgent from 'https-proxy-agent'
+import type { PathLike } from 'node:fs'
 import type { ListrDefaultRendererValue, ListrGetRendererClassFromValue, ListrRendererValue, ListrTask } from 'listr2'
 
 export interface AssetDownloads {
@@ -43,7 +44,7 @@ export function displayErrorLog(errorLog: unknown[]): void;
 
 export function setupLogging(log: unknown[]): void;
 
-export function writeErrorLogFile(destination: string, errorLog: unknown[]): Promise<void>;
+export function writeErrorLogFile(destination: PathLike, errorLog: unknown[]): Promise<void>;
 
 export function proxyStringToObject(proxyString: string): ProxyObject;
 


### PR DESCRIPTION
## Problems with BFJ (Big Friendly JSON) in this project
- `bfj` has been archived repository for some time now
- Its use has been limited as `writeErrorLogFile` loads the `errorLog` completely into memory, transforms it, then writes it to a log file using `bfj`. Obviously if the data is so large that it requires `bfj`, then loading it completely into to memory would more than likely crash the process.
- `bfj` does not have `@types/bfj` available.
