### PR TITLE
feat: Improve 'setupLogging' to instantiate a log array if none is provided

### DIFF
--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -210,7 +210,7 @@ export async function writeErrorLogFile (
 /**
  * Init listeners for log messages, transform them into proper format and logs/displays them
  */
-export function setupLogging (log: (WarningMessage | ErrorMessage)[]) {
+export function setupLogging (log: (WarningMessage | ErrorMessage)[] = []) {
   function errorLogger (level: LogMessage['level'], error: unknown) {
     const logMessage = {
       ts: new Date().toJSON(),
@@ -228,6 +228,8 @@ export function setupLogging (log: (WarningMessage | ErrorMessage)[]) {
   logEmitter.addListener('info', (error) => errorLogger('info', error))
   logEmitter.addListener('warning', (error) => errorLogger('warning', error))
   logEmitter.addListener('error', (error) => errorLogger('error', error))
+
+  return log
 }
 
 /**


### PR DESCRIPTION
# Summary

- Modifies the `log` parameter to be optional.
- Returns the `log` value (whether passed-in or instantiated)


## Usage in contentful-export:
```js
  const log = []
  const options = parseOptions(params)

  const listrOptions = createListrOptions(options)

  // Setup custom error listener to store errors for later
  setupLogging(log)
```

New behaviour:
```js
  // Setup custom error listener to store errors for later
  const log = setupLogging()
  const options = parseOptions(params)

  const listrOptions = createListrOptions(options)
```

## Usage in contentful-import:

```js
  const log = []
  const options = parseOptions(params)
  const listrOptions = createListrOptions(options)
  const requestQueue = new PQueue({
    interval: ONE_SECOND,
    intervalCap: options.rateLimit,
    carryoverConcurrencyCount: true
  })

  // Setup custom log listener to store log messages for later
  setupLogging(log)
```

New behaviour:
```js
  // Setup custom log listener to store log messages for later
  const log = setupLogging()
  const options = parseOptions(params)
  const listrOptions = createListrOptions(options)
  const requestQueue = new PQueue({
    interval: ONE_SECOND,
    intervalCap: options.rateLimit,
    carryoverConcurrencyCount: true
  })
```