### PR TITLE
fix: get entity name function optional param [NONE]

### DIFF
--- a/lib/get-entity-name.ts
+++ b/lib/get-entity-name.ts
@@ -1,6 +1,9 @@
 import { isFields, isSysLink } from './type-guards'
 
-export function getEntityName (entity: NonNullable<unknown>): string {
+export function getEntityName (entity?: NonNullable<unknown>): string {
+  if (!entity) {
+    return 'unknown'
+  }
   if ('name' in entity && typeof entity.name === 'string') {
     return attachId(entity.name, entity)
   }


### PR DESCRIPTION
Turns out that the way we use this function doesn't always guaranty an input object. to not break the downstream consumers, we also allow calling this function without input param.  