### PR TITLE
feat: add breaking release rule and trigger v11.0.0 [DX-787]

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         {
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
               "type": "build",
               "scope": "deps",
               "release": "patch"


### PR DESCRIPTION
[DX-787](https://contentful.atlassian.net/browse/DX-787)

## Summary
- Adds `{ "breaking": true, "release": "major" }` to `releaseRules` in the semantic-release config — this rule was missing here, which caused the CMA v12 / Node <22 breaking change to release as `v10.1.7` (patch) instead of `v11.0.0` (major)
- This commit also serves as the explicit trigger for the corrective major release

BREAKING CHANGE: Node < 22 is no longer supported. Consumers must upgrade to Node >= 22 before upgrading to this version. contentful-management has been upgraded to v12.

## Test plan
- [ ] CI passes
- [ ] After merge, semantic-release publishes `v11.0.0`

Generated with [Claude Code](https://claude.com/claude-code)

[DX-787]: https://contentful.atlassian.net/browse/DX-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ