### PR TITLE
fix: avoid disclosing error stack traces in log file write failure

### DIFF
--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -202,8 +202,11 @@ export async function writeErrorLogFile (
     console.log('\nStored the detailed error log file at:')
     console.log(destination)
   } catch (err) {
-    // avoid crashing when writing the log file fails
-    console.error(err)
+    // Avoid crashing when writing the log file fails. Surface a generic
+    // message rather than the raw error to avoid disclosing stack traces or
+    // other internal details (CWE-209).
+    const reason = isNativeError(err) ? err.message : 'Unknown error'
+    console.error(`\nFailed to write the detailed error log file: ${reason}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- `writeErrorLogFile`'s catch block logged the raw error object via `console.error(err)`, which prints the full stack trace — exposing file paths, third-party library internals, and other implementation details (CWE-209 / OWASP A3 Sensitive Data Exposure).
- Replaced it with a sanitized, generic message that surfaces only the error's `message` text, preserving the original "don't crash on log-write failure" intent while not leaking internals.
- Reuses the existing `isNativeError` import already used elsewhere in the module — no new dependencies.

## Test plan
- [x] `npx jest test/logging.test.js` — all 14 tests pass (incl. `writes error log file to disk`)
- [x] `npx tsc --noEmit` reports no errors for `logging.ts`

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR addresses a sensitive data exposure vulnerability (CWE-209 / OWASP A3) in the error logging module. The `writeErrorLogFile` function's catch block previously logged the raw error object via `console.error(err)`, which exposed stack traces containing file paths, third-party library internals, and other implementation details. The fix sanitizes the error output by extracting only the error message using the existing `isNativeError` utility, while maintaining the original graceful-failure behavior.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Replaces `console.error(err)` with a sanitized message in the catch block of `writeErrorLogFile` in `lib/logging.ts`, preventing disclosure of stack traces and internal details (CWE-209 / OWASP A3)</li>

<li>Uses the already-imported `isNativeError` utility from `node:util/types` to safely extract only the error's `message` property, avoiding new dependencies</li>

<li>Preserves the original "don't crash on log-write failure" intent with a generic user-facing message: 'Failed to write the detailed error log file: <reason>'</li>

</ul>
</details>

</div>